### PR TITLE
Add flag to suppress superfluous output to allow piping to jq

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,8 @@ func main() {
 	var (
 		target  = flag.String("u", "", "The URL to connect to")
 		origin  = flag.String("o", "", "The origin to use in the WS request")
+		quiet   = flag.Bool("q", false, "Only read from the socket")
+		quietMode bool
 		h       headers
 		origURL *url.URL
 	)
@@ -49,10 +51,15 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	ws := connect(*target, makeHeader(h), origURL)
-	trapCtrlC(ws)
-	go write(ws)
-	read(ws)
+	if *quiet == true {
+		quietMode = true
+	} else {
+		quietMode = false
+	}
+	ws := connect(*target, makeHeader(h), origURL, quietMode)
+	trapCtrlC(ws, quietMode)
+	go write(ws, quietMode)
+	read(ws, quietMode)
 }
 
 func makeHeader(h headers) http.Header {
@@ -64,8 +71,10 @@ func makeHeader(h headers) http.Header {
 	return httpH
 }
 
-func connect(addr string, h http.Header, origin *url.URL) *websocket.Conn {
-	log.Printf("connecting to %s...", addr)
+func connect(addr string, h http.Header, origin *url.URL, quietMode bool) *websocket.Conn {
+	if !quietMode {
+		log.Printf("connecting to %s...", addr)
+	}
 	conf, err := websocket.NewConfig(addr, addr)
 	if err != nil {
 		log.Fatal(err)
@@ -76,17 +85,21 @@ func connect(addr string, h http.Header, origin *url.URL) *websocket.Conn {
 	if err != nil {
 		log.Fatal(err)
 	}
-	log.Print("ready, exit with CTRL+C.")
+	if !quietMode {
+		log.Print("ready, exit with CTRL+C.")
+	}
 	return ws
 }
 
 // Graceful shutdown
-func trapCtrlC(c *websocket.Conn) {
+func trapCtrlC(c *websocket.Conn, quietMode bool) {
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt)
 	go func() {
 		for range ch {
-			fmt.Println("\nexiting")
+			if !quietMode {
+				fmt.Println("\nexiting")
+			}
 			c.Close()
 			os.Exit(0)
 		}
@@ -94,7 +107,11 @@ func trapCtrlC(c *websocket.Conn) {
 }
 
 // Send STDIN lines to websocket server.
-func write(ws *websocket.Conn) {
+func write(ws *websocket.Conn, quietMode bool) {
+	if !quietMode {
+		return
+	}
+
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		t := scanner.Text()
@@ -104,13 +121,17 @@ func write(ws *websocket.Conn) {
 }
 
 // Read from websocket and print messages to STDOUT
-func read(ws *websocket.Conn) {
+func read(ws *websocket.Conn, quietMode bool) {
 	msg := make([]byte, 16384)
 	for {
 		n, err := ws.Read(msg)
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Printf("<< %s\n", msg[:n])
+		if !quietMode {
+			fmt.Printf("<< %s\n", msg[:n])
+		} else {
+			fmt.Printf("%s\n", msg[:n])
+		}
 	}
 }


### PR DESCRIPTION
I don't know golang well so but this change allows me to do `wsc ... -q | jq .` to pipe the output of my JSON websocket stream to jq and get it pretty printed on the command line which can be useful for debugging purposes.